### PR TITLE
feat: add VibeForge mood-playlist agent (agents/24-vibeforge)

### DIFF
--- a/agents/24-vibeforge/.env.example
+++ b/agents/24-vibeforge/.env.example
@@ -1,0 +1,2 @@
+# Required — free tier at console.groq.com
+GROQ_API_KEY=your_groq_api_key_here

--- a/agents/24-vibeforge/README.md
+++ b/agents/24-vibeforge/README.md
@@ -1,0 +1,93 @@
+# VibeForge
+
+A LangGraph agent that turns a natural-language mood or activity description into a
+10-track playlist, with a self-correcting Critic loop for genre diversity, artist
+diversity, and mood fit.
+
+**Framework**: LangGraph
+**LLM**: Llama 3.3 70B (Groq, free tier)
+
+## What it does
+
+1. **Mood Analyst** — extracts primary emotion, energy level, BPM range, and genre
+   preferences from your input
+2. **Music Curator** — builds a 10-track playlist matching that analysis
+3. **Critic** — scores the playlist 1-10 on genre diversity, artist diversity, and
+   mood coherence
+4. If the score is below 7, the Critic's feedback is fed back into the Curator (up
+   to 2 refinement passes) before the playlist is finalised
+
+```
+Mood Analyst → Music Curator → Critic (score < 7?) → Music Curator (refine) → Critic → Finalise
+```
+
+## Setup
+
+```bash
+pip install -r requirements.txt
+cp .env.example .env
+# Edit .env and add your Groq API key
+```
+
+Get a free API key: https://console.groq.com (no credit card needed)
+
+## Run
+
+```bash
+python agent.py --mood "late night lo-fi study session"
+python agent.py --mood "sunny road trip, windows down" --context "summer, weekend"
+```
+
+## Sample Output
+
+```
+Generating a playlist for: late night lo-fi study session
+
+🎭 Mood Analyst — calm focus, low energy, BPM 70-90
+🎧 Music Curator — Building 'Late Night Focus'
+🧐 Critic — 8/10 (accepted)
+
+============================================================
+🎵 Late Night Focus
+============================================================
+A relaxed, concentrated atmosphere for a late night study session — mellow
+beats and warm textures that stay in the background without breaking focus.
+
+ 1. Rainy Night — Jinsang [lo-fi, 90 BPM]
+    https://open.spotify.com/search/Jinsang%20Rainy%20Night
+ 2. Aruarian Dance — Nujabes [lo-fi, 95 BPM]
+    https://open.spotify.com/search/Nujabes%20Aruarian%20Dance
+ ...
+
+Genres: lo-fi hip hop, electronic, instrumental  |  Energy: LOW
+```
+
+## Architecture
+
+```
+User Input → [Mood Analyst] → mood analysis (emotion, energy, BPM, genres)
+                                      │
+                                      ▼
+                            [Music Curator] → 10-track playlist
+                                      │
+                                      ▼
+                                 [Critic] → score 1-10
+                              score < 7 │  score >= 7
+                        (max 2 retries) │
+                                      ▼  ▼
+                        back to Curator   Finalise
+```
+
+## Tests
+
+```bash
+pip install pytest
+pytest test_agent.py -v
+```
+
+## Full project
+
+This is a trimmed CLI demo. The full project — a Streamlit web UI, session
+memory that learns your preferences over time, live weather/time context, real
+Spotify link enrichment, and two additional generation modes — lives at
+[github.com/niravpatidar37/mood-playlist-agent](https://github.com/niravpatidar37/mood-playlist-agent).

--- a/agents/24-vibeforge/agent.py
+++ b/agents/24-vibeforge/agent.py
@@ -28,7 +28,7 @@ from pydantic import BaseModel, Field, ValidationError
 
 load_dotenv()
 
-if sys.stdout.encoding.lower() != "utf-8":  # emoji-safe output on legacy Windows consoles
+if (sys.stdout.encoding or "").lower() != "utf-8":  # emoji-safe output on legacy Windows consoles
     sys.stdout.reconfigure(encoding="utf-8")
 
 DEFAULT_MODEL = "llama-3.3-70b-versatile"
@@ -116,7 +116,7 @@ CRITIC_PROMPT = """You are a music playlist quality critic. Evaluate the playlis
 Return ONLY valid JSON — no markdown, no extra text:
 {"score": 8, "issues": ["issue 1"], "feedback": "actionable instructions for the curator"}
 
-Score 8-10: excellent, accept as-is. Score 5-7: decent but fixable. Score 1-4: significant problems."""
+Score 7-10: excellent, accept as-is. Score 4-6: decent but fixable. Score 1-3: significant problems."""
 
 
 # --- LLM helpers ------------------------------------------------------------------
@@ -131,10 +131,19 @@ def strip_fences(raw: str) -> str:
     return raw[start:end + 1] if start != -1 and end > start else raw
 
 
+def content_to_text(content) -> str:
+    """Normalize AIMessage.content, which may be a string or a list of content parts."""
+    if isinstance(content, str):
+        return content
+    if isinstance(content, list):
+        return "".join(part if isinstance(part, str) else str(part.get("text", "")) for part in content)
+    return str(content)
+
+
 def invoke_json(llm: ChatGroq, messages: list, schema: type, label: str, max_attempts: int = 3):
     """Invoke the LLM, parse + validate the JSON response, retrying on failure."""
     for attempt in range(max_attempts):
-        raw = str(llm.invoke(messages).content)
+        raw = content_to_text(llm.invoke(messages).content)
         try:
             return schema(**json.loads(strip_fences(raw)))
         except (json.JSONDecodeError, ValidationError) as exc:

--- a/agents/24-vibeforge/agent.py
+++ b/agents/24-vibeforge/agent.py
@@ -1,0 +1,279 @@
+"""
+VibeForge — mood-based playlist agent with a self-correcting Critic loop.
+
+A LangGraph state machine: a Mood Analyst extracts emotional context from a
+natural-language mood/activity description, a Music Curator builds a 10-track
+playlist from that analysis, and a Critic scores it 1-10 on genre diversity,
+artist diversity, and mood fit. If the score is below the bar, the Critic's
+feedback is fed back into the Curator (up to two refinement passes) before the
+playlist is finalised.
+
+Usage:
+    python agent.py --mood "late night lo-fi study session"
+    python agent.py --mood "sunny road trip, windows down" --context "summer, weekend"
+"""
+
+import argparse
+import json
+import re
+import sys
+from typing import Literal, Optional, TypedDict
+from urllib.parse import quote_plus
+
+from dotenv import load_dotenv
+from langchain_core.messages import HumanMessage, SystemMessage
+from langchain_groq import ChatGroq
+from langgraph.graph import END, StateGraph
+from pydantic import BaseModel, Field, ValidationError
+
+load_dotenv()
+
+if sys.stdout.encoding.lower() != "utf-8":  # emoji-safe output on legacy Windows consoles
+    sys.stdout.reconfigure(encoding="utf-8")
+
+DEFAULT_MODEL = "llama-3.3-70b-versatile"
+ACCEPT_SCORE = 7
+MAX_REFINEMENTS = 2
+
+
+# --- Schemas ------------------------------------------------------------------
+
+class Track(BaseModel):
+    title: str
+    artist: str
+    genre: str
+    bpm: Optional[int] = None
+
+
+class Playlist(BaseModel):
+    name: str = Field(description="Creative playlist name reflecting the mood")
+    mood_summary: str = Field(description="2-3 sentence description of the mood and why these songs fit")
+    energy_level: Literal["low", "medium", "high"]
+    tracks: list[Track] = Field(description="Exactly 10 tracks", min_length=10, max_length=10)
+    genres: list[str] = Field(description="Primary genres featured in this playlist")
+
+
+class MoodAnalysis(BaseModel):
+    primary_emotion: str
+    energy_level: Literal["low", "medium", "high"]
+    bpm_range: str
+    recommended_genres: list[str]
+    avoid_genres: list[str]
+
+
+class Critique(BaseModel):
+    score: int = Field(ge=1, le=10, description="Overall quality score 1-10")
+    issues: list[str] = Field(description="Specific problems found in the playlist")
+    feedback: str = Field(description="Actionable instructions for the curator to fix the issues")
+
+
+class AgentState(TypedDict):
+    mood_input: str
+    context: str
+    model: str
+    mood_analysis: Optional[MoodAnalysis]
+    playlist: Optional[Playlist]
+    critique: Optional[Critique]
+    refinement_attempts: int
+
+
+# --- Prompts --------------------------------------------------------------------
+
+ANALYST_PROMPT = """You are a music psychologist and emotion expert.
+Analyse the user's mood/activity input and return ONLY valid JSON — no markdown, no extra text:
+{
+  "primary_emotion": "string",
+  "energy_level": "low|medium|high",
+  "bpm_range": "60-80",
+  "recommended_genres": ["string"],
+  "avoid_genres": ["string"]
+}"""
+
+CURATOR_PROMPT = """You are a world-class DJ and music curator with encyclopaedic knowledge of songs \
+across all genres, eras, and languages. Given a mood analysis (and optional critic feedback), curate a \
+10-track playlist. Return ONLY valid JSON — no markdown, no extra text:
+{
+  "name": "string",
+  "mood_summary": "string",
+  "energy_level": "low|medium|high",
+  "genres": ["string"],
+  "tracks": [{"title": "string", "artist": "string", "genre": "string", "bpm": 120}]
+}
+Rules:
+- Exactly 10 tracks that genuinely fit the mood.
+- Quality mix: 2-3 well-known hits, 3 cult classics or deep cuts, 3-4 fresh discoveries the \
+listener likely hasn't heard.
+- Genre diversity: no single genre exceeds 40% of the playlist (max 4 of 10 tracks).
+- Artist diversity: no artist appears more than twice.
+- BPM values must fall within the bpm_range from the mood analysis."""
+
+CRITIC_PROMPT = """You are a music playlist quality critic. Evaluate the playlist against these criteria:
+1. Genre diversity — no single genre > 40% of tracks
+2. Artist diversity — no artist appears more than twice
+3. Mood coherence — tracks genuinely fit the stated mood and energy level
+4. Track authenticity — all tracks are real, well-known recordings
+
+Return ONLY valid JSON — no markdown, no extra text:
+{"score": 8, "issues": ["issue 1"], "feedback": "actionable instructions for the curator"}
+
+Score 8-10: excellent, accept as-is. Score 5-7: decent but fixable. Score 1-4: significant problems."""
+
+
+# --- LLM helpers ------------------------------------------------------------------
+
+def strip_fences(raw: str) -> str:
+    """Extract JSON from LLM output — handles fenced blocks and bare unfenced JSON."""
+    raw = raw.strip()
+    match = re.search(r"```[^\n]*\n(.*?)```", raw, re.DOTALL)
+    if match:
+        return match.group(1).strip()
+    start, end = raw.find("{"), raw.rfind("}")
+    return raw[start:end + 1] if start != -1 and end > start else raw
+
+
+def invoke_json(llm: ChatGroq, messages: list, schema: type, label: str, max_attempts: int = 3):
+    """Invoke the LLM, parse + validate the JSON response, retrying on failure."""
+    for attempt in range(max_attempts):
+        raw = str(llm.invoke(messages).content)
+        try:
+            return schema(**json.loads(strip_fences(raw)))
+        except (json.JSONDecodeError, ValidationError) as exc:
+            if attempt == max_attempts - 1:
+                raise RuntimeError(f"{label} returned invalid JSON after {max_attempts} attempts") from exc
+            messages = [*messages, HumanMessage(content=f"Your response had errors: {exc}. Return valid JSON only.")]
+
+
+def search_links(title: str, artist: str) -> tuple[str, str]:
+    q = quote_plus(f"{artist} {title}")
+    return f"https://open.spotify.com/search/{q}", f"https://www.youtube.com/results?search_query={q}"
+
+
+# --- Graph nodes ---------------------------------------------------------------
+
+def analyse_mood(state: AgentState) -> AgentState:
+    llm = ChatGroq(model=state["model"], temperature=0.7)
+    user_msg = f"Mood / activity: {state['mood_input']}"
+    if state["context"]:
+        user_msg += f"\nContext: {state['context']}"
+    analysis = invoke_json(
+        llm, [SystemMessage(content=ANALYST_PROMPT), HumanMessage(content=user_msg)], MoodAnalysis, "Mood Analyst"
+    )
+    print(f"🎭 Mood Analyst — {analysis.primary_emotion}, {analysis.energy_level} energy, BPM {analysis.bpm_range}")
+    return {**state, "mood_analysis": analysis}
+
+
+def curate_playlist(state: AgentState) -> AgentState:
+    llm = ChatGroq(model=state["model"], temperature=0.8)
+    analysis = state["mood_analysis"]
+    assert analysis is not None
+    content = f"Mood analysis:\n{analysis.model_dump_json(indent=2)}"
+    critique = state.get("critique")
+    if critique and state["refinement_attempts"] > 0:
+        content += (
+            f"\n\nCritic review (score {critique.score}/10 — needs improvement):\n"
+            f"Issues: {'; '.join(critique.issues)}\nFeedback: {critique.feedback}\n"
+            "Please address ALL issues above in your revised playlist."
+        )
+    playlist = invoke_json(
+        llm, [SystemMessage(content=CURATOR_PROMPT), HumanMessage(content=content)], Playlist, "Music Curator"
+    )
+    verb = "Refining" if state["refinement_attempts"] > 0 else "Building"
+    print(f"🎧 Music Curator — {verb} '{playlist.name}'")
+    return {**state, "playlist": playlist}
+
+
+def critique_playlist(state: AgentState) -> AgentState:
+    llm = ChatGroq(model=state["model"], temperature=0.3)
+    playlist = state["playlist"]
+    assert playlist is not None
+    content = f"Mood: {state['mood_input']}\n\nPlaylist:\n{playlist.model_dump_json(indent=2)}"
+    critique = invoke_json(
+        llm, [SystemMessage(content=CRITIC_PROMPT), HumanMessage(content=content)], Critique, "Critic"
+    )
+    verdict = "accepted" if critique.score >= ACCEPT_SCORE else "needs refinement"
+    print(f"🧐 Critic — {critique.score}/10 ({verdict})")
+    return {**state, "critique": critique}
+
+
+def route_after_critique(state: AgentState) -> str:
+    critique = state.get("critique")
+    if critique and critique.score < ACCEPT_SCORE and state["refinement_attempts"] < MAX_REFINEMENTS:
+        return "refine"
+    return "finalise"
+
+
+def increment_attempts(state: AgentState) -> AgentState:
+    return {**state, "refinement_attempts": state["refinement_attempts"] + 1}
+
+
+def finalise(state: AgentState) -> AgentState:
+    return state
+
+
+def build_graph():
+    g = StateGraph(AgentState)
+    g.add_node("analyse_mood", analyse_mood)
+    g.add_node("curate_playlist", curate_playlist)
+    g.add_node("critique_playlist", critique_playlist)
+    g.add_node("increment_attempts", increment_attempts)
+    g.add_node("finalise", finalise)
+
+    g.set_entry_point("analyse_mood")
+    g.add_edge("analyse_mood", "curate_playlist")
+    g.add_edge("curate_playlist", "critique_playlist")
+    g.add_conditional_edges(
+        "critique_playlist", route_after_critique, {"refine": "increment_attempts", "finalise": "finalise"}
+    )
+    g.add_edge("increment_attempts", "curate_playlist")
+    g.add_edge("finalise", END)
+    return g.compile()
+
+
+# --- CLI --------------------------------------------------------------------------
+
+def print_playlist(playlist: Playlist) -> None:
+    print(f"\n{'=' * 60}")
+    print(f"🎵 {playlist.name}")
+    print(f"{'=' * 60}")
+    print(f"{playlist.mood_summary}\n")
+    for i, track in enumerate(playlist.tracks, 1):
+        spotify_url, youtube_url = search_links(track.title, track.artist)
+        bpm = f"{track.bpm} BPM" if track.bpm else ""
+        print(f"{i:>2}. {track.title} — {track.artist} [{track.genre}{', ' + bpm if bpm else ''}]")
+        print(f"    {spotify_url}")
+    print(f"\nGenres: {', '.join(playlist.genres)}  |  Energy: {playlist.energy_level.upper()}")
+
+
+def run(mood: str, context: str, model: str) -> Playlist:
+    graph = build_graph()
+    initial: AgentState = {
+        "mood_input": mood,
+        "context": context,
+        "model": model,
+        "mood_analysis": None,
+        "playlist": None,
+        "critique": None,
+        "refinement_attempts": 0,
+    }
+    final = graph.invoke(initial)
+    playlist = final["playlist"]
+    if playlist is None:
+        raise RuntimeError("Pipeline failed to produce a playlist.")
+    return playlist
+
+
+def main():
+    parser = argparse.ArgumentParser(description="VibeForge — AI mood-based playlist generator")
+    parser.add_argument("--mood", help="Mood or activity description, e.g. 'rainy day, studying'")
+    parser.add_argument("--context", default="", help="Extra context, e.g. 'weekend, summer'")
+    parser.add_argument("--model", default=DEFAULT_MODEL, help="Groq model to use")
+    args = parser.parse_args()
+
+    mood = args.mood or input("How are you feeling? ")
+    print(f"\nGenerating a playlist for: {mood}\n")
+    playlist = run(mood, args.context, args.model)
+    print_playlist(playlist)
+
+
+if __name__ == "__main__":
+    main()

--- a/agents/24-vibeforge/metadata.yaml
+++ b/agents/24-vibeforge/metadata.yaml
@@ -1,0 +1,11 @@
+title: vibeforge
+description: Turns a mood or activity description into a 10-track playlist, with a self-correcting Critic loop for genre/artist diversity and mood fit
+author: niravpatidar37
+language: python
+framework: langgraph
+tags: [music, playlist, mood, langgraph, self-correction, groq]
+industry: entertainment
+difficulty: intermediate
+llm: llama-3.3-70b-versatile (Groq, free tier)
+entrypoint: agent.py
+requirements: requirements.txt

--- a/agents/24-vibeforge/requirements.txt
+++ b/agents/24-vibeforge/requirements.txt
@@ -1,0 +1,5 @@
+langchain-core==1.4.8
+langchain-groq==1.1.3
+langgraph==1.2.6
+pydantic==2.12.5
+python-dotenv==1.2.2

--- a/agents/24-vibeforge/test_agent.py
+++ b/agents/24-vibeforge/test_agent.py
@@ -1,0 +1,55 @@
+"""Unit tests for VibeForge's schemas and helpers — no API key needed."""
+
+import pytest
+from pydantic import ValidationError
+
+from agent import Playlist, Track, search_links, strip_fences
+
+
+def make_track(**kwargs):
+    defaults = {"title": "Blinding Lights", "artist": "The Weeknd", "genre": "Synth-pop"}
+    return Track(**{**defaults, **kwargs})
+
+
+def make_playlist(n_tracks: int = 10) -> Playlist:
+    tracks = [make_track(title=f"Song {i}", artist=f"Artist {i}") for i in range(n_tracks)]
+    return Playlist(
+        name="Test Vibes", mood_summary="A test playlist", energy_level="medium", genres=["Pop"], tracks=tracks
+    )
+
+
+class TestPlaylist:
+    def test_valid_playlist(self):
+        assert len(make_playlist().tracks) == 10
+
+    def test_too_few_tracks_raises(self):
+        with pytest.raises(ValidationError):
+            make_playlist(n_tracks=3)
+
+    def test_too_many_tracks_raises(self):
+        with pytest.raises(ValidationError):
+            make_playlist(n_tracks=13)
+
+    def test_invalid_energy_level_raises(self):
+        with pytest.raises(ValidationError):
+            Playlist(
+                name="Bad", mood_summary="bad", energy_level="extreme", genres=[],
+                tracks=[make_track(title=f"Song {i}", artist=f"A {i}") for i in range(10)],
+            )
+
+
+class TestSearchLinks:
+    def test_returns_spotify_and_youtube_urls(self):
+        spotify_url, youtube_url = search_links("Blinding Lights", "The Weeknd")
+        assert spotify_url.startswith("https://open.spotify.com/search/")
+        assert youtube_url.startswith("https://www.youtube.com/results?search_query=")
+        assert "Weeknd" in spotify_url
+
+
+class TestStripFences:
+    def test_extracts_fenced_json(self):
+        raw = '```json\n{"a": 1}\n```'
+        assert strip_fences(raw) == '{"a": 1}'
+
+    def test_extracts_bare_json(self):
+        assert strip_fences('here you go: {"a": 1} thanks') == '{"a": 1}'


### PR DESCRIPTION
Slim resubmission of #133, trimmed per review feedback to the standard 6-file catalog layout: `agent.py`, `README.md`, `requirements.txt`, `.env.example`, `metadata.yaml`, `test_agent.py`. 445 lines total.

Also fixes the naming inconsistency called out in review — everything is now consistently named **VibeForge** (folder, metadata title, README).

`agent.py` is a self-contained LangGraph pipeline: Mood Analyst → Music Curator → Critic, with the Critic's feedback looped back into the Curator (up to 2 refinements) when the score is below 7/10. Runs with `python agent.py --mood "..."` in under a minute against Groq's free tier.

The full project (Streamlit UI, session memory, live weather context, real Spotify link enrichment, two additional generation modes) stays in my own repo: https://github.com/niravpatidar37/mood-playlist-agent — linked from this agent's README.

Closes/supersedes #133.

## Summary by Sourcery

Add the VibeForge LangGraph agent for generating and iteratively improving mood-based playlists from the command line.

New Features:
- Add the VibeForge CLI agent to generate mood-based 10-track playlists from natural-language input.
- Add self-correcting playlist evaluation and refinement based on genre diversity, artist diversity, and mood fit.
- Provide Spotify and YouTube search links for generated tracks.

Enhancements:
- Add structured validation for mood analyses, playlists, tracks, and critiques, with resilient parsing of model responses.
- Provide a documented, standalone LangGraph workflow using Groq-hosted Llama 3.3.

Build:
- Add pinned runtime dependencies and environment configuration guidance for the new agent.

Documentation:
- Document VibeForge setup, CLI usage, architecture, sample output, tests, and the full project reference.

Tests:
- Add API-independent tests covering playlist validation, link generation, and model JSON response cleanup.